### PR TITLE
fix to validate URLs with date/numeric ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web-scraper-chrome-extension",
-	"version": "0.3.4",
+	"version": "0.3.4.01",
 	"description": "Web data extraction tool implemented as chrome extension",
 	"scripts": {
 		"lint": "eslint --ext .js,.vue src",

--- a/src/scripts/Controller.js
+++ b/src/scripts/Controller.js
@@ -391,6 +391,8 @@ export default class SitemapController {
 								$.each(
 									value.split(',').map(item => item.trim()),
 									function(i, url) {
+										url = url.replace(/\[date<(.*?)><(.*?)><(.*?)>]/g, ''); // remove date interval specs
+										url = url.replace(/\[(\d+)-(\d+)(:(\d+))?]/g, ''); // remove range patterns
 										isValid = isUrlValid(url) ? isValid : false;
 									}
 								);

--- a/src/scripts/Controller.js
+++ b/src/scripts/Controller.js
@@ -382,21 +382,21 @@ export default class SitemapController {
 							message: 'The start URLs are not valid. Please use "," as a seperator.',
 							callback: function(value) {
 								function isUrlValid(url) {
-									return /^(https?|s?ftp):\/\/(((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:)*@)?(((\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5]))|((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.?)(:\d*)?)(\/((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)+(\/(([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)*)*)?)?(\?((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|[\uE000-\uF8FF]|\/|\?)*)?(#((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|\/|\?)*)?$/i.test(
-										url
-									);
+									try {
+										new URL(url);
+										return true;
+									} catch (e) {
+										if (e instanceof TypeError) {
+											return false;
+										}
+										throw e;
+									}
 								}
 
-								let isValid = true;
-								$.each(
-									value.split(',').map(item => item.trim()),
-									function(i, url) {
-										url = url.replace(/\[date<(.*?)><(.*?)><(.*?)>]/g, ''); // remove date interval specs
-										url = url.replace(/\[(\d+)-(\d+)(:(\d+))?]/g, ''); // remove range patterns
-										isValid = isUrlValid(url) ? isValid : false;
-									}
-								);
-								return isValid;
+								return value
+									.split(',')
+									.map(item => item.trim())
+									.every(isUrlValid);
 							},
 						},
 					},


### PR DESCRIPTION
Provided pattern only checks for valid URLs, so I made a simple fix to remove date and range specs before applying it.
Possible improvements:
- use more human friendly URL validator
- disallow date/range patterns in some parts of URL (e.g. scheme)