### PR TITLE
Fix tables: 'this' is not binding in getDataCells

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web-scraper-chrome-extension",
-	"version": "0.3.604",
+	"version": "0.3.605",
 	"description": "Web data extraction tool implemented as chrome extension",
 	"scripts": {
 		"lint": "eslint --ext .js src",

--- a/src/scripts/Selector/SelectorTable.js
+++ b/src/scripts/Selector/SelectorTable.js
@@ -131,7 +131,7 @@ export default class SelectorTable extends Selector {
 		const getDataCells = this.verticalTable
 			? this.getVerticalDataCells
 			: this.getHorizontalDataCells;
-		return tables.flatMap(getDataCells);
+		return tables.flatMap(getDataCells.bind(this));
 	}
 
 	getDataColumns() {


### PR DESCRIPTION
Table selector does not work because `this` is not binding in `getDataCells`
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes#Boxing_with_prototype_and_static_methods
