### PR TITLE
adding_validation_of_sitemapVersion_before_import_of_sitemap

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -245,6 +245,9 @@
 	"sitemapmodel_empty_message": { "message": "Empty value is possible model" },
 	"sitemapjson_invalid_message": { "message": "JSON is not valid" },
 	"sitemapjson_empty_message": { "message": "Sitemap JSON is required and cannot be empty" },
+	"sitemap_invalid_specificationVersion": {
+		"message": "The version of the sitemap is younger than the plugin version. Please update the plugin"
+	},
 	"sitemap_url_pattern_empty_message": {
 		"message": "URL pattern is required and can't be empty"
 	},

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -267,6 +267,9 @@
 	"sitemapjson_empty_message": {
 		"message": "JSON карта обхода обязателен и не может быть пустым"
 	},
+	"sitemap_invalid_specificationVersion": {
+		"message": "Версия карты обхода новее чем версия плагина. Пожалуйста обновите плагин"
+	},
 	"sitemap_url_pattern_empty_message": { "message": "Шаблон URL не может быть пустым" },
 	"sitemap_url_pattern_invalid_message": {
 		"message": "Шаблон URL должен быть корректным регулярным выражением"

--- a/src/scripts/Controller.js
+++ b/src/scripts/Controller.js
@@ -15,7 +15,7 @@ import SelectorList from './SelectorList';
 import SelectorTable from './Selector/SelectorTable';
 import Model from './Model';
 import Translator from './Translator';
-
+import SitemapSpecMigrationManager from './SitemapSpecMigration/Manager';
 export default class SitemapController {
 	constructor(store, templateDir) {
 		this.store = store;
@@ -609,7 +609,22 @@ export default class SitemapController {
 											};
 										}
 									}
-
+									// check sitemapSpecificationVersion not younger than plugin version
+									if (sitemap.hasOwnProperty('sitemapSpecificationVersion')) {
+										const versionOfSitemap =
+											sitemap.sitemapSpecificationVersion;
+										if (
+											versionOfSitemap >
+											SitemapSpecMigrationManager.currentVersion()
+										) {
+											return {
+												valid: false,
+												message: Translator.getTranslationByKey(
+													'sitemap_invalid_specificationVersion'
+												),
+											};
+										}
+									}
 									// check for start urls or url pattern
 									if (
 										Object.hasOwn(sitemap, 'startUrls') &&


### PR DESCRIPTION
Previously, there was no check if, when importing a sitemap, its version was younger than the plugin version. This commit fixes that and adds a check