### PR TITLE
Bug fix in update selector func

### DIFF
--- a/src/scripts/Sitemap.js
+++ b/src/scripts/Sitemap.js
@@ -157,18 +157,19 @@ export default class Sitemap {
 		if (selector === undefined || selector.type !== selectorData.type) {
 			if (selector) {
 				if (selector.canHaveChildSelectors()) {
+					//custom logic: we don’t delete children, but redefined them a parent
 					const children = this.selectors.filter(selectorFromList =>
 						selectorFromList.parentSelectors.includes(selector.uuid)
 					);
 					const newSelector = SelectorList.createSelector(selectorData);
 					children.forEach(child => {
 						const parentUuidIndex = child.parentSelectors.indexOf(selector.uuid);
-						console.log(child.parentSelector);
-						child.parentSelector[parentUuidIndex] = newSelector.uuid;
+						child.parentSelectors[parentUuidIndex] = newSelector.uuid;
 					});
 					selector = newSelector;
 				} else {
 					this.deleteSelector(selector);
+					selector = SelectorList.createSelector(selectorData);
 				}
 			} else {
 				selector = SelectorList.createSelector(selectorData);

--- a/src/scripts/Sitemap.js
+++ b/src/scripts/Sitemap.js
@@ -156,9 +156,23 @@ export default class Sitemap {
 		// selector is undefined when creating a new one and delete old one, if it exist
 		if (selector === undefined || selector.type !== selectorData.type) {
 			if (selector) {
-				this.deleteSelector(selector);
+				if (selector.canHaveChildSelectors()) {
+					const children = this.selectors.filter(selectorFromList =>
+						selectorFromList.parentSelectors.includes(selector.uuid)
+					);
+					const newSelector = SelectorList.createSelector(selectorData);
+					children.forEach(child => {
+						const parentUuidIndex = child.parentSelectors.indexOf(selector.uuid);
+						console.log(child.parentSelector);
+						child.parentSelector[parentUuidIndex] = newSelector.uuid;
+					});
+					selector = newSelector;
+				} else {
+					this.deleteSelector(selector);
+				}
+			} else {
+				selector = SelectorList.createSelector(selectorData);
 			}
-			selector = SelectorList.createSelector(selectorData);
 		}
 
 		// update child selectors


### PR DESCRIPTION

Bug fix for a situation when we change the selector type, but its children are removed even if the new selector type supports child selectors